### PR TITLE
Add dark themed web page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,39 @@
+body {
+  background-color: #000;
+  color: #fff;
+  font-family: 'Roboto Mono', monospace;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  text-align: center;
+  padding: 2rem;
+  background: linear-gradient(180deg, #111, #000);
+  box-shadow: 0 0 10px #f00;
+}
+
+button, .panel {
+  background-color: #222;
+  color: #f00;
+  border: 2px solid #f00;
+  padding: 10px 20px;
+  margin: 10px;
+  cursor: pointer;
+  font-family: 'Roboto Mono', monospace;
+}
+
+button:hover, .panel:hover {
+  background-color: #330000;
+}
+
+#eye {
+  width: 200px;
+  margin: 2rem auto;
+  animation: blink 2s infinite;
+}
+
+@keyframes blink {
+  0%, 20%, 100% { opacity: 1; }
+  10% { opacity: 0.2; }
+}

--- a/img/eye.svg
+++ b/img/eye.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="#ff4444" />
+      <stop offset="100%" stop-color="#220000" />
+    </radialGradient>
+  </defs>
+  <circle cx="50" cy="50" r="40" fill="url(#glow)" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terminator Control Panel</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>Terminator Control Panel</h1>
+  </header>
+  <img src="img/eye.svg" id="eye" alt="Red Eye" />
+  <div id="running" class="panel">SYSTEM OVERRIDE</div>
+  <button class="panel">Engage Protocol</button>
+
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,9 @@
+// Simple running text effect
+const runText = document.getElementById('running');
+if (runText) {
+  let offset = 0;
+  setInterval(() => {
+    offset = (offset + 1) % window.innerWidth;
+    runText.style.transform = `translateX(-${offset}px)`;
+  }, 50);
+}


### PR DESCRIPTION
## Summary
- create a simple Terminator-style index page
- style page with black theme and red accents
- add a glowing eye image
- include a small JS animation

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68408675acd8832584c4fecfde2830e7